### PR TITLE
Homework 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "hafiz/php_2025_hw3",
+    "type": "project",
+    "autoload": {
+        "psr-4": {
+            "Hafiz\\Php2025Hw3\\": "src/"
+        }
+    },
+    "authors": [
+        {
+            "name": "Hafizov Timur",
+            "email": "shsjs339@gmail.com"
+        }
+    ],
+    "require": {
+        "hafiz/simple-logger": "^1.0"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,55 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d7a0722ff4625f91665c1947561b5297",
+    "packages": [
+        {
+            "name": "hafiz/simple-logger",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dragon2323343/simple-logger.git",
+                "reference": "c1e0d040de0f2a262b456d9d88097060ad4c4f89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dragon2323343/simple-logger/zipball/c1e0d040de0f2a262b456d9d88097060ad4c4f89",
+                "reference": "c1e0d040de0f2a262b456d9d88097060ad4c4f89",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Hafiz\\SimpleLogger\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Hafizov Timur",
+                    "email": "shsjs339@gmail.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/Dragon2323343/simple-logger/issues",
+                "source": "https://github.com/Dragon2323343/simple-logger/tree/v1.0.0"
+            },
+            "time": "2025-02-15T14:18:59+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/test.php
+++ b/test.php
@@ -1,0 +1,7 @@
+<?php
+
+use Hafiz\SimpleLogger\Logger;
+
+require __DIR__ . '/vendor/autoload.php';
+
+Logger::log();


### PR DESCRIPTION
Создал и опубликовал новый пакет SimpleLogger на [Packagist](https://packagist.org/packages/hafiz/simple-logger#v1.0.0). Пакет предназначен для простого вывода сообщения, подтверждающего успешное подключение пакета.

Ссылки:
- Репозиторий: [GitHub - simple-logger](https://github.com/Dragon2323343/simple-logger)
- Пакет на Packagist: [SimpleLogger на Packagist](https://packagist.org/packages/hafiz/simple-logger)

Установка через Composer - composer require hafiz/simple-logger